### PR TITLE
fix broken html tags during translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can extend polyglot and provide your own translator drivers. To do so, follo
     return [
         'default' => env('POLYGLOT_DEFAULT', 'bing'),
         'translators' => [
-            'microsoft' => [
+            'bing' => [
                 'driver' => 'azure',
                 'key' => env('BING_TRANSLATE_API_KEY'),
             ],

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
     "autoload": {
         "psr-4": {
             "Plank\\Polyglot\\": "src/"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Contracts/AbstractTranslator.php
+++ b/src/Contracts/AbstractTranslator.php
@@ -4,29 +4,38 @@ namespace Plank\Polyglot\Contracts;
 
 abstract class AbstractTranslator implements Translator
 {
+    protected int $limit = 25000;
+
     protected string $format = 'text';
 
     protected string $source = 'auto';
 
     protected string $target;
 
-    abstract public function translate(string $string): string;
+    abstract public function translate(string $text): string;
 
-    public function translateTo(string $string, string $target, ?string $source = null): string
+    public function translateTo(string $text, string $target, ?string $source = null): string
     {
         if ($source !== null) {
             $this->from($source);
         }
 
-        return $this->to($target)->translate($string);
+        return $this->to($target)->translate($text);
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
+        if (is_string($strings)) {
+            $strings = match ($this->format) {
+                'html' => html_split($strings, $this->limit),
+                default => str_split($strings, $this->limit),
+            };
+        }
+
         return array_map(fn ($string) => $this->translate($string), $strings);
     }
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array
     {
         if ($source !== null) {
             $this->from($source);

--- a/src/Contracts/NestedTranslator.php
+++ b/src/Contracts/NestedTranslator.php
@@ -23,12 +23,12 @@ abstract class NestedTranslator implements Translator
         return $this->client->translateTo($text, $target, $source);
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         return $this->client->translateBatch($strings);
     }
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array
     {
         return $this->client->translateBatchTo($strings, $target, $source);
     }

--- a/src/Contracts/Translator.php
+++ b/src/Contracts/Translator.php
@@ -4,13 +4,13 @@ namespace Plank\Polyglot\Contracts;
 
 interface Translator
 {
-    public function translate(string $string): string;
+    public function translate(string $text): string;
 
-    public function translateTo(string $string, string $target, ?string $source = null): string;
+    public function translateTo(string $text, string $target, ?string $source = null): string;
 
-    public function translateBatch(array $strings): array;
+    public function translateBatch(array|string $strings): array;
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array;
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array;
 
     public function languages(?string $target = null): array;
 

--- a/src/Drivers/AmazonTranslate.php
+++ b/src/Drivers/AmazonTranslate.php
@@ -9,6 +9,8 @@ use Plank\Polyglot\Exceptions\ValidationException;
 
 class AmazonTranslate extends AbstractTranslator
 {
+    protected int $limit = 10000;
+
     protected TranslateClient $client;
 
     public function __construct(array $credentials, string $region, string $version = 'latest', string $format = 'html')
@@ -24,10 +26,8 @@ class AmazonTranslate extends AbstractTranslator
 
     public function translate(string $text): string
     {
-        if (strlen($text) > 10000) {
-            $strings = str_split($text, 10000);
-
-            return implode('', $this->translateBatch($strings));
+        if (strlen($text) > $this->limit) {
+            return implode('', $this->translateBatch($text));
         }
 
         $response = $this->sendTranslateRequest($text, [
@@ -36,15 +36,6 @@ class AmazonTranslate extends AbstractTranslator
         ]);
 
         return $response['TranslatedText'];
-    }
-
-    public function translateBatch(array $strings): array
-    {
-        foreach ($strings as $key => $text) {
-            $strings[$key] = $this->translate($text);
-        }
-
-        return $strings;
     }
 
     public function sendTranslateRequest(string $text, array $options): Result
@@ -59,9 +50,7 @@ class AmazonTranslate extends AbstractTranslator
 
         $options['Text'] = $text;
 
-        $response = $this->client->translateText($options);
-
-        return $response;
+        return $this->client->translateText($options);
     }
 
     public function languages($target = null): array

--- a/src/Drivers/AmazonTranslate.php
+++ b/src/Drivers/AmazonTranslate.php
@@ -26,16 +26,29 @@ class AmazonTranslate extends AbstractTranslator
 
     public function translate(string $text): string
     {
-        if (strlen($text) > $this->limit) {
-            return implode('', $this->translateBatch($text));
+        $limit = $this->limit;
+        $format = $this->format;
+        if ($this->format === 'html' && $text === strip_tags($text)) {
+            $this->format = 'text';
         }
 
-        $response = $this->sendTranslateRequest($text, [
-            'TargetLanguageCode' => $this->target,
-            'SourceLanguageCode' => $this->source,
-        ]);
+        $this->limit = $this->format === 'text' ? 10000 : 102400;
 
-        return $response['TranslatedText'];
+        $options = ['TargetLanguageCode' => $this->target, 'SourceLanguageCode' => $this->source];
+        if (strlen($text) > $this->limit) {
+            $this->format = $format;
+            $response = ['TranslatedText' => implode('', $this->translateBatch($text))];
+        } elseif ($this->format !== 'text') {
+            $options['Document'] = ['ContentType' => ($this->format === 'html' ? 'text/html' : 'text/plain')];
+            $response = $this->sendTranslateDocumentRequest($text, $options);
+        } else {
+            $response = $this->sendTranslateRequest($text, $options);
+        }
+
+        $this->limit = $limit;
+        $this->format = $format;
+
+        return $response['TranslatedText'] ?? $response['TranslatedDocument']['Content'];
     }
 
     public function sendTranslateRequest(string $text, array $options): Result
@@ -51,6 +64,25 @@ class AmazonTranslate extends AbstractTranslator
         $options['Text'] = $text;
 
         return $this->client->translateText($options);
+    }
+
+    public function sendTranslateDocumentRequest(string $content, array $options): Result
+    {
+        if (empty($options['SourceLanguageCode'])) {
+            $options['SourceLanguageCode'] = 'auto';
+        }
+
+        if (empty($options['TargetLanguageCode'])) {
+            throw new ValidationException('Amazon document translation requires target locale.');
+        }
+
+        if (! is_array($options['Document']) || empty($options['Document']['ContentType'])) {
+            throw new ValidationException('Amazon document translation requires a Document with ContentType.');
+        }
+
+        $options['Document']['Content'] = $content;
+
+        return $this->client->translateDocument($options);
     }
 
     public function languages($target = null): array

--- a/src/Drivers/GoogleTranslate.php
+++ b/src/Drivers/GoogleTranslate.php
@@ -47,7 +47,7 @@ class GoogleTranslate extends NestedTranslator
         return $output;
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         $output = parent::translateBatch($strings);
 
@@ -60,7 +60,7 @@ class GoogleTranslate extends NestedTranslator
         return $output;
     }
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array
     {
         $output = parent::translateBatchTo($strings, $target, $source);
 

--- a/src/Drivers/GoogleV2Translate.php
+++ b/src/Drivers/GoogleV2Translate.php
@@ -10,6 +10,8 @@ use Plank\Polyglot\Exceptions\ValidationException;
 
 class GoogleV2Translate extends AbstractTranslator
 {
+    protected int $limit = 102400;
+
     protected TranslateClient $client;
 
     protected string $model;
@@ -26,10 +28,8 @@ class GoogleV2Translate extends AbstractTranslator
 
     public function translate(string $text): string
     {
-        if (strlen($text) > 102400) {
-            $strings = str_split($text, 102400);
-
-            return implode('', $this->translateBatch($strings));
+        if (strlen($text) > $this->limit) {
+            return implode('', $this->translateBatch($text));
         }
 
         $response = $this->sendTranslateRequest($text, [
@@ -42,7 +42,7 @@ class GoogleV2Translate extends AbstractTranslator
         return $response['text'];
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         $response = $this->sendTranslateRequest($strings, [
             'target' => $this->target,

--- a/src/Drivers/GoogleV3Translate.php
+++ b/src/Drivers/GoogleV3Translate.php
@@ -43,7 +43,7 @@ class GoogleV3Translate extends AbstractTranslator
         return $text;
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         $response = $this->sendTranslateRequest($strings);
 

--- a/src/Drivers/StackTranslate.php
+++ b/src/Drivers/StackTranslate.php
@@ -34,12 +34,12 @@ class StackTranslate extends NestedTranslator
         return $this->tryAllClients(fn (Translator $client) => $client->translateTo($text, $target, $source));
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         return $this->tryAllClients(fn (Translator $client) => $client->translateBatch($strings));
     }
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array
     {
         return $this->tryAllClients(fn (Translator $client) => $client->translateBatchTo($strings, $target, $source));
     }

--- a/src/Drivers/StichozaTranslate.php
+++ b/src/Drivers/StichozaTranslate.php
@@ -2,7 +2,6 @@
 
 namespace Plank\Polyglot\Drivers;
 
-use GuzzleHttp\Client;
 use Plank\Polyglot\Contracts\AbstractTranslator;
 use Stichoza\GoogleTranslate\GoogleTranslate;
 

--- a/src/Drivers/StichozaTranslate.php
+++ b/src/Drivers/StichozaTranslate.php
@@ -8,6 +8,8 @@ use Stichoza\GoogleTranslate\GoogleTranslate;
 
 class StichozaTranslate extends AbstractTranslator
 {
+    protected int $limit = 15000;
+
     protected GoogleTranslate $client;
 
     public function __construct()
@@ -17,10 +19,8 @@ class StichozaTranslate extends AbstractTranslator
 
     public function translate(string $text): string
     {
-        if (strlen($text) > 15000) {
-            $strings = str_split($text, 15000);
-
-            return implode('', $this->translateBatch($strings));
+        if (strlen($text) > $this->limit) {
+            return implode('', $this->translateBatch($text));
         }
 
         return $this->client->setSource($this->source)->setTarget($this->target)->translate($text);

--- a/src/TranslatorManager.php
+++ b/src/TranslatorManager.php
@@ -182,12 +182,12 @@ class TranslatorManager extends Manager implements Translator
         return $this->translator()->translateTo($string, $target, $source);
     }
 
-    public function translateBatch(array $strings): array
+    public function translateBatch(array|string $strings): array
     {
         return $this->translator()->translateBatch($strings);
     }
 
-    public function translateBatchTo(array $strings, string $target, ?string $source = null): array
+    public function translateBatchTo(array|string $strings, string $target, ?string $source = null): array
     {
         return $this->translator()->translateBatchTo($strings, $target, $source);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,40 @@
+<?php
+
+if (!function_exists('html_split')) {
+    /**
+     *
+     * Return an array of safely split HTML strings
+     *
+     * @param  string  $html
+     * @param  int  $maxLength
+     * @return array
+     */
+    function html_split(string $html, int $maxLength = 1): array {
+        if ($html === strip_tags($html)) {
+            return str_split($html, $maxLength);
+        }
+
+        // Regex to find all end tags
+        preg_match_all('/<\/[^>]+>/', $html, $matches, PREG_OFFSET_CAPTURE);
+        $endTags = $matches[0];
+
+        $chunks = [];
+        $lastSplit = 0;
+        $lastTagPos = 0;
+        foreach ($endTags as $tag) {
+            $tagPos = $tag[1] + strlen($tag[0]);
+            if ($tagPos - $lastSplit > $maxLength) {
+                $chunks[] = substr($html, $lastSplit, $lastTagPos - $lastSplit);
+                $lastSplit = $lastTagPos;
+            }
+            $lastTagPos = $tagPos;
+        }
+
+        // Add the remaining part
+        if ($lastSplit < strlen($html)) {
+            $chunks = array_merge($chunks, str_split(substr($html, $lastSplit), $maxLength));
+        }
+
+        return $chunks;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -16,14 +16,18 @@ if (! function_exists('html_split')) {
 
         $chunks = [];
         $lastSplit = 0;
-        $lastTagPos = 0;
+        $lastPosition = 0;
         foreach ($endTags as $tag) {
-            $tagPos = $tag[1] + strlen($tag[0]);
-            if ($tagPos - $lastSplit > $maxLength) {
-                $chunks[] = substr($html, $lastSplit, $lastTagPos - $lastSplit);
-                $lastSplit = $lastTagPos;
+            $position = $tag[1] + strlen($tag[0]);
+            $currentSize = $position - $lastSplit;
+            $lastSize = $lastPosition - $lastSplit;
+
+            // If adding this tag exceeds maxLength and lastSize is between 0 and maxLength, split here
+            if ($currentSize > $maxLength && $lastSize > 0 && $lastSize < $maxLength) {
+                $chunks[] = substr($html, $lastSplit, $lastSize);
+                $lastSplit = $lastPosition;
             }
-            $lastTagPos = $tagPos;
+            $lastPosition = $position;
         }
 
         // Add the remaining part

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,15 +1,11 @@
 <?php
 
-if (!function_exists('html_split')) {
+if (! function_exists('html_split')) {
     /**
-     *
      * Return an array of safely split HTML strings
-     *
-     * @param  string  $html
-     * @param  int  $maxLength
-     * @return array
      */
-    function html_split(string $html, int $maxLength = 1): array {
+    function html_split(string $html, int $maxLength = 1): array
+    {
         if ($html === strip_tags($html)) {
             return str_split($html, $maxLength);
         }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+describe('html_split helper', function () {
+    it('can split html safely', function () {
+        $html = '<p>First paragraph</p><p>Second paragraph</p>';
+        $expected = ['<p>First paragraph</p>', '<p>Second paragraph</p>'];
+        $max = 25;
+
+        expect(html_split($html, $max))->toBe($expected)->not->toBe(str_split($html, $max));
+    });
+
+    it('falls back to str_split on simple strings', function () {
+        $text = fake()->paragraph(4, false);
+
+        expect(html_split($text, 25))->toBe(str_split($text, 25));
+        expect(html_split($text))->toBe(str_split($text));
+    });
+
+    it('falls back to str_split when length is smaller than any html tag', function () {
+        $html = fake()->randomHtml();
+
+        // smallest html tag is 4 characters
+        for ($i = 1; $i < 5; $i++) {
+            expect(html_split($html, $i))->toBe(str_split($html, $i));
+        }
+    });
+
+    it('can handle long strings used in the translation service', function () {
+        $html = '';
+        while (strlen($html) < 200000) {
+            $html = fake()->randomHtml(5, 25);
+        }
+
+        foreach ([10000, 15000, 25000, 102400] as $max) {
+            $chunks = html_split($html, $max);
+
+            expect($chunks)
+                ->toBeArray()
+                ->not->toBeEmpty()
+                ->and(implode('', $chunks))
+                ->toBe($html);
+
+            $lengths = array_map(fn ($chunk) => strlen($chunk), $chunks);
+
+            expect($lengths)->each(fn ($chunk) => $chunk->toBeLessThanOrEqual($max));
+        }
+    });
+});


### PR DESCRIPTION
###### closes #3

## Summary
<!-- Short description of the changes/fixes made. What does this PR solve? -->
- Fixes issues with long text where incorrect splits result in html tags being treated as actual text to translate
- Adds better html support for AmazonTranslate by using its real-time document translation feature

## Testing
<!-- List the tests that cover the functionality of this PR and any manual testing instructions -->
- Copy over some html content that is about 30-50k in length
- run str_split and run html_split on that content, use limit 10000, to see how str_split sometimes cuts html tags in two
- Run translate with format html and confirm that the translated content doesn't have broken up html
- Re-test with the amazon driver - the can be seen visually in another project